### PR TITLE
Allow MD viewer to load image from base64

### DIFF
--- a/frontend/src/components/MarkdownVIewer/MarkdownViewer.tsx
+++ b/frontend/src/components/MarkdownVIewer/MarkdownViewer.tsx
@@ -1,11 +1,19 @@
-import Markdown from "react-markdown";
+import Markdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import remarkMath from "remark-math";
 
+function urlTransformer(url: string) {
+  if (/^data:image\/(png|jpeg);base64,/.test(url)) {
+    return url;
+  }
+
+  return defaultUrlTransform(url);
+}
+
 export const MarkdownViewer = ({ markdown }: { markdown: string }) => {
   return (
-    <Markdown remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}>
+    <Markdown remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]} skipHtml={false} urlTransform={urlTransformer}>
       {markdown}
     </Markdown>
   );


### PR DESCRIPTION
Previously, MarkdownViewer is aggressively sanitizing our data url using the `defaultUrlTransform` function. Lets provide a custom transform function to prevent it from sanitizing our dataurl

Before:
> ![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g10/assets/72195240/bd96b22d-cf6e-4f64-9074-191826be630b)

After:
> ![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g10/assets/72195240/664cc760-c185-4706-a546-0069d56d45f4)
