### PR TITLE
Make question backend/frontend accept testcases.zip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - mongo
     volumes:
       - ./question_service:/usr/src/app
+      - questions_test_cases:/app/question_test_cases
+      
   match-worker:
     container_name: match-worker_1
     image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/match-worker_1:latest
@@ -168,4 +170,5 @@ services:
 volumes:
   postgres_data:
   mongo-dev-data:
+  questions_test_cases:
   profile_pictures:

--- a/docker_compose_dev.yml
+++ b/docker_compose_dev.yml
@@ -13,6 +13,7 @@ services:
       - mongo
     volumes:
       - ./question_service:/usr/src/app
+      - questions_test_cases:/app/question_test_cases
   
   user-service:
     container_name: user-service
@@ -139,3 +140,4 @@ services:
 volumes:
   postgres_data:
   mongo-dev-data:
+  questions_test_cases:

--- a/frontend/src/api/questions.ts
+++ b/frontend/src/api/questions.ts
@@ -41,14 +41,18 @@ export async function fetchQuestion(_id: string) {
  * @param question The question to add to the database
  * @returns
  */
-export async function addQuestion(question : Question) {
+export async function addQuestion(question : Question, testCasesFile : File) {
 
-    const response : AxiosResponse = await questionServiceClient.post('/api/questions', {
+    const formData = new FormData();
+    formData.append("testcases", testCasesFile);
+    formData.append("question", JSON.stringify({
         title: question.title,
         description: question.descMd,
         topics: question.topics,
         difficulty: question.difficulty
-    })
+    })) 
+
+    const response : AxiosResponse = await questionServiceClient.post('/api/questions', formData);
 
     const resData = response.data;
     
@@ -80,13 +84,21 @@ export async function delQuestion(_id : string) {
  * @param question The new question info to add to the database
  * @returns
  */
-export async function updateQuestion(_id: string, question: Question) {
-    const response : AxiosResponse = await questionServiceClient.put(`/api/questions/${_id}`, {
+export async function updateQuestion(_id: string, question: Question, testCasesFile : File | null) {
+
+    const formData = new FormData();
+    if (testCasesFile !== null) {
+        formData.append("testcases", testCasesFile);
+    }
+    
+    formData.append("question", JSON.stringify({
         title: question.title,
         description: question.descMd,
         topics: question.topics,
         difficulty: question.difficulty
-    })
+    })) 
+
+    const response : AxiosResponse = await questionServiceClient.put(`/api/questions/${_id}`, formData)
 
     const resData = response.data;
     const resQuestion : Question = new Question(

--- a/frontend/src/components/QuestionEditor/QuestionEditor.component.tsx
+++ b/frontend/src/components/QuestionEditor/QuestionEditor.component.tsx
@@ -24,10 +24,11 @@ import { MarkdownEditor } from "../MarkdownEditor/MarkdownEditor.component";
 import { CloseableTag } from "../CloseableTag/CloseableTag.component";
 import { diffToScheme } from "../../helper/UIHelper";
 import { CheckIcon, CloseIcon } from "@chakra-ui/icons";
+import { MarkdownViewer } from "../MarkdownVIewer/MarkdownViewer";
 
 type QuestionEditorProp = {
   question?: Question;
-  onSubmit?: (question: Question) => Promise<void>;
+  onSubmit?: (question: Question, testCasesFile: File | null) => Promise<void>;
   onCancel?: () => void;
 };
 
@@ -46,6 +47,7 @@ export const QuestionEditor = (prop: QuestionEditorProp) => {
   const [topics, setTopics] = useState(question?.topics ?? []);
   const [type, setType] = useState("");
   const [highlightTopic, setHighlightTopic] = useState("");
+  const [testCasesFile, setTestCasesFile] = useState<File | null>(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -70,6 +72,13 @@ export const QuestionEditor = (prop: QuestionEditorProp) => {
     setType("");
   };
 
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    if (event.target.files && event.target.files[0]) {
+      const uploadedFile = event.target.files[0];
+      setTestCasesFile(uploadedFile);
+    }
+  }
+
   /**
    * Checks if a question is valid. A question is valid if title, description and topics are not empty.
    * @returns boolean
@@ -93,6 +102,7 @@ export const QuestionEditor = (prop: QuestionEditorProp) => {
     if (!checkValid()) {
       toast({
         title: "Invalid Question",
+        description: "Please check if all fields of the question are provided",
         status: "error",
         isClosable: true,
       });
@@ -102,7 +112,7 @@ export const QuestionEditor = (prop: QuestionEditorProp) => {
     setIsSubmitting(true);
 
     try {
-      await onSubmit(buildQuestion());
+      await onSubmit(buildQuestion(), testCasesFile);
       console.log("Submit success!");
     } catch (err : any) {
       toast({
@@ -197,10 +207,12 @@ export const QuestionEditor = (prop: QuestionEditorProp) => {
             ))}
           </Wrap>
 
-          <FormLabel paddingTop="4">Input Files</FormLabel>
-          <Input type="file" aria-hidden="true" accept=".zip" />
-          <FormLabel paddingTop="4">Output Files</FormLabel>
-          <Input type="file" aria-hidden="true" accept=".zip" />
+          <FormLabel paddingTop="4">Testcases</FormLabel>
+          <MarkdownViewer markdown="Please submit a zip file containing all your testcases for this question. 
+          The input for the testcases should be suffixed with a `.in`, and the expected outputs with a `.out`
+          For every `xxx.in` file, please include a `xxx.out` file.
+          "/>
+          <Input type="file" aria-hidden="true" accept=".zip" onChange={handleFileChange}/>
         </FormControl>
         <Box width="100%" height="100%" overflow="auto">
           <MarkdownEditor onChange={setDescription} markdown={description} />

--- a/frontend/src/pages/CreateQuestionPage/CreateQuestion.page.tsx
+++ b/frontend/src/pages/CreateQuestionPage/CreateQuestion.page.tsx
@@ -30,9 +30,13 @@ const CreateQuestion = () => {
   };
 
   //actual submit function that calls the API
-  const trySubmit = async (qn: Question) => {
+  const trySubmit = async (qn: Question, testCasesFile : File | null) => {
     try {
-      const questionFromResponse : Question = await addQuestion(qn);
+      if (testCasesFile === null) {
+        throw Error('Please upload a testcase file!');
+      }
+
+      const questionFromResponse : Question = await addQuestion(qn, testCasesFile);
 
       dispatch(addQuestions([questionFromResponse]));
       nav(-1);

--- a/frontend/src/pages/EditQuestionPage/EditQuestion.page.tsx
+++ b/frontend/src/pages/EditQuestionPage/EditQuestion.page.tsx
@@ -16,8 +16,8 @@ const EditQuestion = () => {
     nav(-1);
   };
 
-  const updateQn = async (qn : Question) => {
-    const updatedQn : Question = await updateQuestion(qn._id, qn);
+  const updateQn = async (qn : Question, testCasesFile : File | null) => {
+    const updatedQn : Question = await updateQuestion(qn._id, qn, testCasesFile);
     dispatch(modifyQuestion(updatedQn));
     nav(-1);
   } 

--- a/question_service/.gitignore
+++ b/question_service/.gitignore
@@ -1,0 +1,1 @@
+uploads/

--- a/question_service/package-lock.json
+++ b/question_service/package-lock.json
@@ -17,6 +17,7 @@
         "multer": "^1.4.5-lts.1"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.4",
         "@types/cors": "^2.8.16",
         "@types/express": "^4.17.21",
         "@types/multer": "^1.4.10",
@@ -94,6 +95,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
+    },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.4.tgz",
+      "integrity": "sha512-/pYie/76O0TTqU4L/z1XqQ5mA5QvScaP/EO3lpH7iQ6/AjioYyuvi2IAmQeimuTTnytl03e9g8YFYkGV2Bxojw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",

--- a/question_service/package-lock.json
+++ b/question_service/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "fs-extra": "^11.1.1",
         "mongoose": "^7.5.3",
         "multer": "^1.4.5-lts.1"
       },
@@ -20,6 +21,7 @@
         "@types/adm-zip": "^0.5.4",
         "@types/cors": "^2.8.16",
         "@types/express": "^4.17.21",
+        "@types/fs-extra": "^11.0.4",
         "@types/multer": "^1.4.10",
         "nodemon": "^3.0.1",
         "ts-node-dev": "^2.0.0",
@@ -157,11 +159,30 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -759,6 +780,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -843,6 +877,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -1015,6 +1054,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/kareem": {
       "version": "2.5.1",
@@ -1965,6 +2015,14 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/question_service/package.json
+++ b/question_service/package.json
@@ -19,6 +19,7 @@
     "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.4",
     "@types/cors": "^2.8.16",
     "@types/express": "^4.17.21",
     "@types/multer": "^1.4.10",

--- a/question_service/package.json
+++ b/question_service/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "fs-extra": "^11.1.1",
     "mongoose": "^7.5.3",
     "multer": "^1.4.5-lts.1"
   },
@@ -22,6 +23,7 @@
     "@types/adm-zip": "^0.5.4",
     "@types/cors": "^2.8.16",
     "@types/express": "^4.17.21",
+    "@types/fs-extra": "^11.0.4",
     "@types/multer": "^1.4.10",
     "nodemon": "^3.0.1",
     "ts-node-dev": "^2.0.0",

--- a/question_service/src/controller/questionController.ts
+++ b/question_service/src/controller/questionController.ts
@@ -40,9 +40,14 @@ async function handleTestCaseUpload(questionId : string, zipFilePath : string) {
             await fs.rm(path.join(outDir, file), { recursive: true, force: true });
         }))
 
-    } catch (error) {
-        console.error('Error processing file:', error);
-        throw error;
+        const remainingFiles = await fs.readdir(outDir);
+        if (remainingFiles.length === 0) {
+            throw Error('no files uploaded!');
+        }
+
+    } catch (error : any) {
+        console.error('Error uploading files:', error.message);
+        throw Error(`Error uploading files: ${error.message}`);
     } finally {
         await fs.unlink(zipFilePath);
     }
@@ -80,8 +85,8 @@ export const fetchQuestion = async (req : any, res : any) => {
             difficulty: question.difficulty
         })
 
-    } catch (error) {
-        res.status(400).json({ message: 'Invalid ID. Question not found in database.' })
+    } catch (error: any) {
+        res.status(400).json({ message: `${error.message}` })
     }
 }
 
@@ -116,7 +121,7 @@ export const addQuestion = async (req : any, res : any) => {
             difficulty: question.difficulty
         })
     } catch (error : any) {
-        res.status(400).json({ message: 'Invalid question data', error: error.message })
+        res.status(400).json({ message: `Invalid question data: ${error.message}`})
     }
 }
 
@@ -164,8 +169,8 @@ export const updateQuestion = async (req : any, res : any) => {
             topics: question.topics,
             difficulty: question.difficulty
         })
-    } catch (error) {
-        res.status(400).json({ message: 'Invalid question data.' })
+    } catch (error : any) {
+        res.status(400).json({ message: error.message})
     }
 }
        
@@ -186,7 +191,7 @@ export const deleteQuestion = async (req : any, res : any) => {
         await fs.rm(`/app/question_test_cases/${question._id}`);
         await question.deleteOne();
         res.status(200).json({ message: 'Question removed' });
-    } catch (error) {
-        res.status(404).json({ message: 'Question not found' })
+    } catch (error: any) {
+        res.status(404).json({ message: error.message })
     }
 }

--- a/question_service/src/controller/questionController.ts
+++ b/question_service/src/controller/questionController.ts
@@ -10,7 +10,7 @@ function handleTestCaseUpload(questionId : string, zipFilePath : string) {
         const outDir = `/app/question_test_cases/${questionId}/`;
         zip.extractAllTo(outDir, true);
 
-        
+
         //only store .in file if .out file exists
         const files = fs.readdirSync(outDir);
         const inFiles = files.filter(file => file.endsWith('.in'));
@@ -29,15 +29,15 @@ function handleTestCaseUpload(questionId : string, zipFilePath : string) {
         const randomFiles = files.filter(file => !(file.endsWith('.in') || file.endsWith('.out')));
 
         invalidInFiles.forEach(file => {
-            fs.unlinkSync(path.join(outDir, file));
+            fs.rmSync(path.join(outDir, file), { recursive: true, force: true });
         })
 
         invalidOutFiles.forEach(file => {
-            fs.unlinkSync(path.join(outDir, file));
+            fs.rmSync(path.join(outDir, file), { recursive: true, force: true });
         })
 
         randomFiles.forEach(file => {
-            fs.unlinkSync(path.join(outDir, file));
+            fs.rmSync(path.join(outDir, file), { recursive: true, force: true });
         })
 
     } catch (error) {
@@ -100,11 +100,12 @@ export const addQuestion = async (req : any, res : any) => {
 
     try {
         const id = await getNextSequenceValue('questionIndex');
-        handleTestCaseUpload(id, req.file.path);
-
+        
         const question = await Question.create({
             id, title, description, topics, difficulty
         })
+
+        handleTestCaseUpload(question._id.toString(), req.file.path);
 
         res.status(201).json({
             id : question.id,

--- a/question_service/src/middleware/storage.js
+++ b/question_service/src/middleware/storage.js
@@ -1,3 +1,0 @@
-const multer = require('multer');
-const fs = require('fs');
-const unzipper = require('unzipper');

--- a/question_service/src/middleware/storage.ts
+++ b/question_service/src/middleware/storage.ts
@@ -1,0 +1,3 @@
+import multer from 'multer';
+
+export const upload = multer({ dest: 'uploads/' });

--- a/question_service/src/model/questionModel.ts
+++ b/question_service/src/model/questionModel.ts
@@ -13,7 +13,6 @@ const questionSchema = new mongoose.Schema({
     description: {
         type: String,
         required: true,
-        unique: true,
         trim: true,
     },
     topics: {

--- a/question_service/src/routes/questionRouter.ts
+++ b/question_service/src/routes/questionRouter.ts
@@ -1,12 +1,13 @@
 import express from 'express';
 import { fetchAllQuestions, addQuestion, updateQuestion, deleteQuestion, fetchQuestion  } from '../controller/questionController';
+import { upload } from '../middleware/storage';
 
 const router = express.Router();
 
 router.get('/', fetchAllQuestions);
-router.post('/', addQuestion)
+router.post('/', upload.single('testcases'), addQuestion)
 router.get('/:id', fetchQuestion)
-router.put('/:id', updateQuestion);
+router.put('/:id', upload.single('testcases'), updateQuestion);
 router.delete('/:id', deleteQuestion)
 
 


### PR DESCRIPTION
This PR depends on #59 

Upon create/edit question, the qn service will create  the testcases directory for question with `_id` at the shared store with path `/app/testcases/:_id`

i might add some additional validation on the backend to make sure each `.in` file have a corresponding `.out`

----------------------
Error will be thrown if no testcase file is provided when creating question (editing question will not throw error)
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g10/assets/72195240/8bd0ad9c-867e-4b52-aa55-34170cd12615)

--------------------------
Server will reject file if it is not a `.zip`
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g10/assets/72195240/44b209b2-f143-4372-8abb-3cf020c4e4a4)
