### PR TITLE
Automatically build and push docker images to registry

### DIFF
--- a/.github/workflows/build_push_registry.yml
+++ b/.github/workflows/build_push_registry.yml
@@ -1,0 +1,86 @@
+name: Selectively Build and Push to Artifact Registry
+
+on:
+  push:
+    branches: ["master"]
+
+env:
+  PROJECT_ID: cs3219-400714
+  REGION: asia-southeast1
+  GAR_LOCATION: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/
+
+jobs:
+  build-push-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: Detect Changes in Microservices
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+            user_service:
+              - 'user_service/**'
+            question_service:
+              - 'question_service/**'
+            matching_service:
+              - 'user_service/**'
+            match_worker:
+              - 'match_worker/**'
+            collab_service:
+              - 'collab_service/**'
+      - name: Detect Changes in Microservices
+        id: auth
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: "Use gcloud CLI"
+        run: "gcloud info"
+
+      - name: "Docker auth"
+        run: |-
+          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: 1. Build and Push frontend
+        if: steps.changes.outputs.frontend == 'true'
+        run: |
+          docker-compose build frontend
+          docker-compose push frontend
+
+      - name: 2. Build and Push question-service
+        if: steps.changes.outputs.question_service == 'true'
+        run: |
+          docker-compose build question-service
+          docker-compose push question-service
+
+      - name: 3. Build and Push user-service
+        if: steps.changes.outputs.user_service == 'true'
+        run: |
+          docker-compose build user-service
+          docker-compose push user-service
+
+      - name: 4. Build and Push matching-service
+        if: steps.changes.outputs.matching_service == 'true'
+        run: |
+          docker-compose build matching-service
+          docker-compose push matching-service
+
+      - name: 5. Build and Push match-worker
+        if: steps.changes.outputs.match_worker == 'true'
+        run: |
+          docker-compose build match-worker
+          docker-compose push match-worker
+
+      - name: 6. Build and Push collab-service
+        if: steps.changes.outputs.collab_service == 'true'
+        run: |
+          docker-compose build collab-service
+          docker-compose push collab-service

--- a/.github/workflows/build_push_registry_manual.yml
+++ b/.github/workflows/build_push_registry_manual.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch
 
 env:
-  PROJECT_ID: fake-app-323017
-  REGION: northamerica-northeast1
-  GAR_LOCATION: northamerica-northeast1-docker.pkg.dev/fake-app-323017/repo-1/
+  PROJECT_ID: cs3219-400714
+  REGION: asia-southeast1
+  GAR_LOCATION: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/
 
 jobs:
   build-push-artifact:
@@ -31,8 +31,7 @@ jobs:
           gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build image
-        run: docker build . --file DOCKERFILE_LOCATION --tag ${{ env.GAR_LOCATION }}
-        working-directory: WORKING_DIRECTORY
+        run: docker-compose build
 
       - name: Push image
-        run: docker push ${{ env.GAR_LOCATION }}
+        run: docker-compose push

--- a/.github/workflows/build_push_registry_manual.yml
+++ b/.github/workflows/build_push_registry_manual.yml
@@ -1,0 +1,38 @@
+name: Build and Push to Artifact Registry
+
+on:
+  workflow_dispatch
+
+env:
+  PROJECT_ID: fake-app-323017
+  REGION: northamerica-northeast1
+  GAR_LOCATION: northamerica-northeast1-docker.pkg.dev/fake-app-323017/repo-1/
+
+jobs:
+  build-push-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: "Use gcloud CLI"
+        run: "gcloud info"
+
+      - name: "Docker auth"
+        run: |-
+          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build image
+        run: docker build . --file DOCKERFILE_LOCATION --tag ${{ env.GAR_LOCATION }}
+        working-directory: WORKING_DIRECTORY
+
+      - name: Push image
+        run: docker push ${{ env.GAR_LOCATION }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 /coverage
 
 # production
-/build
+*/build
+*/dist
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,53 +1,13 @@
-# Frontend
+# Running this project
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
-## Available Scripts
-
-In the project directory, you can run:
-
-### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+Simply run `docker-compose up --build` or `docker compose up --build`
 
 
-# Backend
+# For devs
 
-## Question Service
+TBA
 
-The question service depends on a MongoDB instance to serve as the database.
-To start the question service on localhost, run `docker-compose -f .\docker_compose_dev.yml up` at the root of this project.
+To manually push to our service registry, please set up gcloud authentication with our project title
+Then build the images as you would normally with `docker-compose build`
+Then push the builds to the registry with `docker-compose push`
 
-The server should be accessible via the endpoint 
-`localhost:8080/api/questions/`
-
-See the comments `question_service/questionController.js` for the list of endpoints

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,72 @@
 version: '3'
 services:
-  frontend:
-    container_name: frontend
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile.prod
-    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/frontend:latest
-    environment:
-      - REACT_APP_ENV_TYPE=prod
-    ports:
-      - "80:80"
+  # frontend:
+  #   container_name: frontend
+  #   build:
+  #     context: ./frontend
+  #     dockerfile: Dockerfile.prod
+  #   image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/frontend:latest
+  #   environment:
+  #     - REACT_APP_ENV_TYPE=prod
+  #   ports:
+  #     - "80:80"
   
-  question-service:
-    container_name: question-service
-    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/question-service:latest
+  # question-service:
+  #   container_name: question-service
+  #   image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/question-service:latest
+  #   build: 
+  #     context: ./question_service
+  #     dockerfile: Dockerfile.prod
+  #   environment:
+  #     - MONGODB_URI=mongodb://mongo:27017/question_service
+  #     - PORT=8080
+  #   ports:
+  #     - "8080:8080"
+  #   depends_on:
+  #     - mongo
+  #   volumes:
+  #     - ./question_service:/usr/src/app
+
+  user-service:
+    container_name: user-service
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/user-service:latest
     build: 
-      context: ./question_service
+      context: ./user_service
       dockerfile: Dockerfile.prod
     environment:
-      - MONGODB_URI=mongodb://mongo:27017/question_service
-      - PORT=8080
-    ports:
-      - "8080:8080"
-    depends_on:
-      - mongo
-    volumes:
-      - ./question_service:/usr/src/app
+      PORT: 8081
+      SECRET_KEY: ${SECRET_KEY}
 
-  mongo:
-    container_name: mongo
-    image: mongo:6.0
     ports:
-      - "27017:27017"
+      - "8081:8081"
+    depends_on:
+      - postgres
     volumes:
-      - mongo-dev-data:/data/db
+      - ./user_service:/usr/src/app
+      - profile_pictures:/usr/src/app/public/profile_pictures
+
+  # mongo:
+  #   container_name: mongo
+  #   image: mongo:6.0
+  #   ports:
+  #     - "27017:27017"
+  #   volumes:
+  #     - mongo-dev-data:/data/db
+
+  postgres:    
+    container_name: postgres
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      PG_PORT: ${PG_PORT}
+    ports:
+      - "${PG_PORT}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
 
 volumes:
   postgres_data:
   mongo-dev-data:
+  profile_pictures:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,24 +26,94 @@ services:
   #     - mongo
   #   volumes:
   #     - ./question_service:/usr/src/app
+  match-worker:
+    container_name: match-worker_1
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/match-worker_1:latest
+    environment:
+      - CHANNEL_NAME=diff1
+    build:
+      context: ./match_worker
+      dockerfile: Dockerfile.prod
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      matching-service:
+        condition: service_started
 
-  user-service:
-    container_name: user-service
-    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/user-service:latest
-    build: 
-      context: ./user_service
+  match-worker2:
+    container_name: match-worker_2
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/match-worker_1:latest
+    environment:
+      - CHANNEL_NAME=diff2
+    build:
+      context: ./match_worker
+      dockerfile: Dockerfile.prod
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      matching-service:
+        condition: service_started
+
+  match-worker3:
+    container_name: match-worker_3
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/match-worker_1:latest
+    environment:
+      - CHANNEL_NAME=diff3
+    build:
+      context: ./match_worker
+      dockerfile: Dockerfile.prod
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      matching-service:
+        condition: service_started
+
+  match-worker4:
+    container_name: match-worker_4
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/match-worker_1:latest
+    environment:
+      - CHANNEL_NAME=diff4
+    build:
+      context: ./match_worker
+      dockerfile: Dockerfile.prod
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      matching-service:
+        condition: service_started
+
+  # user-service:
+  #   container_name: user-service
+  #   image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/user-service:latest
+  #   build: 
+  #     context: ./user_service
+  #     dockerfile: Dockerfile.prod
+  #   environment:
+  #     PORT: 8081
+  #     SECRET_KEY: ${SECRET_KEY}
+  #   ports:
+  #     - "8081:8081"
+  #   depends_on:
+  #     - postgres
+  #   volumes:
+  #     - ./user_service:/usr/src/app
+  #     - profile_pictures:/usr/src/app/public/profile_pictures
+
+  matching-service:
+    container_name: matching-service
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/matching-service:latest
+    build:
+      context: ./matching_service
       dockerfile: Dockerfile.prod
     environment:
-      PORT: 8081
-      SECRET_KEY: ${SECRET_KEY}
-
+      - PORT=8082
     ports:
-      - "8081:8081"
+      - "8082:8082"
     depends_on:
-      - postgres
+      rabbitmq:
+        condition: service_healthy
     volumes:
-      - ./user_service:/usr/src/app
-      - profile_pictures:/usr/src/app/public/profile_pictures
+      - ./matching_service:/usr/src/app
 
   # mongo:
   #   container_name: mongo
@@ -53,18 +123,34 @@ services:
   #   volumes:
   #     - mongo-dev-data:/data/db
 
-  postgres:    
-    container_name: postgres
-    image: postgres:latest
+  # postgres:    
+  #   container_name: postgres
+  #   image: postgres:latest
+  #   environment:
+  #     POSTGRES_USER: ${POSTGRES_USER}
+  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+  #     POSTGRES_DB: ${POSTGRES_DB}
+  #     PG_PORT: ${PG_PORT}
+  #   ports:
+  #     - "${PG_PORT}:5432"
+  #   volumes:
+  #     - postgres_data:/var/lib/postgresql/data/
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-      PG_PORT: ${PG_PORT}
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
     ports:
-      - "${PG_PORT}:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+services:
+  frontend:
+    container_name: frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/frontend:latest
+    environment:
+      - REACT_APP_ENV_TYPE=prod
+    ports:
+      - "80:80"
+  
+  question-service:
+    container_name: question-service
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/question-service:latest
+    build: 
+      context: ./question_service
+      dockerfile: Dockerfile.prod
+    environment:
+      - MONGODB_URI=mongodb://mongo:27017/question_service
+      - PORT=8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+    volumes:
+      - ./question_service:/usr/src/app
+
+  mongo:
+    container_name: mongo
+    image: mongo:6.0
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-dev-data:/data/db
+
+volumes:
+  postgres_data:
+  mongo-dev-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,31 @@
 version: '3'
 services:
-  # frontend:
-  #   container_name: frontend
-  #   build:
-  #     context: ./frontend
-  #     dockerfile: Dockerfile.prod
-  #   image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/frontend:latest
-  #   environment:
-  #     - REACT_APP_ENV_TYPE=prod
-  #   ports:
-  #     - "80:80"
+  frontend:
+    container_name: frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/frontend:latest
+    environment:
+      - REACT_APP_ENV_TYPE=prod
+    ports:
+      - "80:80"
   
-  # question-service:
-  #   container_name: question-service
-  #   image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/question-service:latest
-  #   build: 
-  #     context: ./question_service
-  #     dockerfile: Dockerfile.prod
-  #   environment:
-  #     - MONGODB_URI=mongodb://mongo:27017/question_service
-  #     - PORT=8080
-  #   ports:
-  #     - "8080:8080"
-  #   depends_on:
-  #     - mongo
-  #   volumes:
-  #     - ./question_service:/usr/src/app
+  question-service:
+    container_name: question-service
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/question-service:latest
+    build: 
+      context: ./question_service
+      dockerfile: Dockerfile.prod
+    environment:
+      - MONGODB_URI=mongodb://mongo:27017/question_service
+      - PORT=8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+    volumes:
+      - ./question_service:/usr/src/app
   match-worker:
     container_name: match-worker_1
     image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/match-worker_1:latest
@@ -82,22 +82,33 @@ services:
       matching-service:
         condition: service_started
 
-  # user-service:
-  #   container_name: user-service
-  #   image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/user-service:latest
-  #   build: 
-  #     context: ./user_service
-  #     dockerfile: Dockerfile.prod
-  #   environment:
-  #     PORT: 8081
-  #     SECRET_KEY: ${SECRET_KEY}
-  #   ports:
-  #     - "8081:8081"
-  #   depends_on:
-  #     - postgres
-  #   volumes:
-  #     - ./user_service:/usr/src/app
-  #     - profile_pictures:/usr/src/app/public/profile_pictures
+  collab-service:
+    container_name: collab-service
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/collab-service:latest
+    environment:
+      PORT: 8083
+    build:
+      context: ./collab_service
+      dockerfile: Dockerfile  #no need for prod file since the server is so basic
+    ports:
+      - "8083:8083"
+
+  user-service:
+    container_name: user-service
+    image: asia-southeast1-docker.pkg.dev/cs3219-400714/peerprep/user-service:latest
+    build: 
+      context: ./user_service
+      dockerfile: Dockerfile.prod
+    environment:
+      PORT: 8081
+      SECRET_KEY: ${SECRET_KEY}
+    ports:
+      - "8081:8081"
+    depends_on:
+      - postgres
+    volumes:
+      - ./user_service:/usr/src/app
+      - profile_pictures:/usr/src/app/public/profile_pictures
 
   matching-service:
     container_name: matching-service
@@ -115,26 +126,27 @@ services:
     volumes:
       - ./matching_service:/usr/src/app
 
-  # mongo:
-  #   container_name: mongo
-  #   image: mongo:6.0
-  #   ports:
-  #     - "27017:27017"
-  #   volumes:
-  #     - mongo-dev-data:/data/db
+  mongo:
+    container_name: mongo
+    image: mongo:6.0
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-dev-data:/data/db
 
-  # postgres:    
-  #   container_name: postgres
-  #   image: postgres:latest
-  #   environment:
-  #     POSTGRES_USER: ${POSTGRES_USER}
-  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-  #     POSTGRES_DB: ${POSTGRES_DB}
-  #     PG_PORT: ${PG_PORT}
-  #   ports:
-  #     - "${PG_PORT}:5432"
-  #   volumes:
-  #     - postgres_data:/var/lib/postgresql/data/
+  postgres:    
+    container_name: postgres
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      PG_PORT: ${PG_PORT}
+    ports:
+      - "${PG_PORT}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+  
 
   rabbitmq:
     image: rabbitmq:3-management

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3'
 services:
+
   frontend:
     container_name: frontend
     build:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install
+COPY . ./
+RUN npm run build
+
+
+# Serve stage
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -3,7 +3,7 @@ FROM node:18-alpine as build
 WORKDIR /app
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm install
+RUN npm ci
 COPY . ./
 RUN npm run build
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "prod": "run-script-os",
     "prod:win32": "set \"REACT_APP_ENV_TYPE=prod\" && npm run start",
     "prod:default": "REACT_APP_ENV_TYPE=prod npm run start",
-    "build": "react-scripts build",
+    "build": "REACT_APP_ENV_TYPE=prod react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/match_worker/Dockerfile.prod
+++ b/match_worker/Dockerfile.prod
@@ -1,0 +1,19 @@
+# Stage 1: Build the application
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: Setup the production environment
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY --from=builder /app/dist ./dist
+EXPOSE 8082
+
+# Command to run the application
+CMD ["npm", "run", "serve"]

--- a/match_worker/package.json
+++ b/match_worker/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc --init && tsc",
-    "start": "ts-node src/index.ts \"diff1\""
+    "start": "ts-node src/index.ts \"diff1\"",
+    "serve": "node dist/index.js"
   },
   "keywords": [],
   "author": "",

--- a/matching_service/Dockerfile.prod
+++ b/matching_service/Dockerfile.prod
@@ -1,0 +1,18 @@
+# Stage 1: Build the application
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: Setup the production environment
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY --from=builder /app/dist ./dist
+
+# Command to run the application
+CMD ["npm", "run", "serve"]

--- a/matching_service/package-lock.json
+++ b/matching_service/package-lock.json
@@ -9,9 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/amqplib": "^0.10.3",
-        "@types/express": "^4.17.20",
-        "@types/socket.io": "^3.0.2",
         "amqplib": "^0.10.3",
         "express": "^4.18.2",
         "nodemon": "^3.0.1",
@@ -20,9 +17,11 @@
         "sqlite3": "^5.1.6"
       },
       "devDependencies": {
+        "@types/amqplib": "^0.10.3",
         "@types/cors": "^2.8.14",
-        "@types/express": "^4.17.19",
+        "@types/express": "^4.17.20",
         "@types/express-jwt": "^7.4.2",
+        "@types/socket.io": "^3.0.2",
         "prisma": "^5.4.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.2.2"
@@ -202,6 +201,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.3.tgz",
       "integrity": "sha512-ZVkD5RqoW6+n84WanWf0a74mT0CVWdXOEEEC9nZvseD//j36XiYGR2phjpHQM6JpYR4vcWnjgUbqFCFG7MB+lw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -352,6 +352,7 @@
       "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-3.0.2.tgz",
       "integrity": "sha512-pu0sN9m5VjCxBZVK8hW37ZcMe8rjn4HHggBN5CbaRTvFwv5jOmuIRZEuddsBPa9Th0ts0SIo3Niukq+95cMBbQ==",
       "deprecated": "This is a stub types definition. socket.io provides its own type definitions, so you do not need this installed.",
+      "dev": true,
       "dependencies": {
         "socket.io": "*"
       }

--- a/matching_service/package.json
+++ b/matching_service/package.json
@@ -2,19 +2,17 @@
   "name": "matching_service",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc --init && tsc",
-    "start": "ts-node src/server.ts"
+    "build": "tsc",
+    "start": "ts-node src/server.ts",
+    "serve": "node dist/server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/amqplib": "^0.10.3",
-    "@types/express": "^4.17.20",
-    "@types/socket.io": "^3.0.2",
     "amqplib": "^0.10.3",
     "express": "^4.18.2",
     "sequelize": "^6.33.0",
@@ -23,8 +21,10 @@
     "nodemon": "^3.0.1"
   },
   "devDependencies": {
+    "@types/amqplib": "^0.10.3",
+    "@types/express": "^4.17.20",
+    "@types/socket.io": "^3.0.2",
     "@types/cors": "^2.8.14",
-    "@types/express": "^4.17.19",
     "@types/express-jwt": "^7.4.2",
     "prisma": "^5.4.2",
     "ts-node-dev": "^2.0.0",

--- a/question_service/Dockerfile.prod
+++ b/question_service/Dockerfile.prod
@@ -1,0 +1,19 @@
+# Stage 1: Build the application
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Setup the production environment
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --only=production
+COPY --from=builder /app/dist ./dist
+EXPOSE 8080
+
+# Command to run the application
+CMD ["node", "./dist/index.js"]

--- a/question_service/Dockerfile.prod
+++ b/question_service/Dockerfile.prod
@@ -3,7 +3,7 @@ FROM node:18-alpine AS builder
 
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 COPY . .
 RUN npm run build
 
@@ -11,7 +11,7 @@ RUN npm run build
 FROM node:18-alpine
 WORKDIR /usr/src/app
 COPY package*.json ./
-RUN npm install --only=production
+RUN npm ci --only=production
 COPY --from=builder /app/dist ./dist
 EXPOSE 8080
 

--- a/question_service/package.json
+++ b/question_service/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon server.js",
-    "start": "ts-node src/index.ts"
+    "start": "ts-node src/index.ts",
+    "build": "tsc",
+    "start:prod": "npm run build && node ./dist/index.js"
   },
   "author": "",
   "license": "ISC",

--- a/user_service/Dockerfile.prod
+++ b/user_service/Dockerfile.prod
@@ -1,0 +1,21 @@
+# Stage 1: Build the application
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npx prisma generate
+RUN npm run build
+
+# Stage 2: Setup the production environment
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY --from=builder /app/node_modules/@prisma/client /app/node_modules/@prisma/client
+COPY --from=builder /app/dist ./dist
+EXPOSE 8081
+
+# Command to run the application
+CMD ["npm", "run", "serve"]

--- a/user_service/package.json
+++ b/user_service/package.json
@@ -7,7 +7,7 @@
     "migrate": "npx prisma db push",
     "start": "npm run migrate && ts-node src/index.ts",
     "build": "tsc",
-    "serve": "node dist/index.js"
+    "serve": "npm run migrate && node dist/index.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR introduces CD, where the github workflow is configured to detect changes in any of our microservices folder and to build and push their docker images to the google artifact registry automatically.

The microservices are defined in the `docker-compose.yml` file and in the github workflow file.

If you add or remove a microservice, please update the github workflow file and docker-compose file accordingly

We have the following microservices defined:
- `frontend`
- `question-service`
- `user-service`
- `matching-service`
- `match-worker`
- `collab-service`

